### PR TITLE
feat: add notification indicator in browser tab

### DIFF
--- a/src/components/ChatLog.tsx
+++ b/src/components/ChatLog.tsx
@@ -4,6 +4,7 @@ import axios from 'axios'
 import ScrollableFeed from 'react-scrollable-feed'
 import ChatLogMessage from './ChatLogMessage'
 import { channel } from '../index'
+import { useTabNotification } from '../hooks/useTabNotification'
 
 export interface Message {
   userId: string
@@ -23,10 +24,12 @@ const Wrapper = styled.div`
 const ChatLog: React.FC = () => {
   const [messages, setMessages] = useState<Message[]>([])
   const [history, setHistory] = useState<Message[]>([])
+  const addNotification = useTabNotification()
 
   useEffect(() => {
     channel.bind('message-event', (data: Message) => {
       const newMessages = [...messages, data]
+      addNotification()
       setMessages(newMessages)
     })
 

--- a/src/hooks/useTabNotification.ts
+++ b/src/hooks/useTabNotification.ts
@@ -1,7 +1,7 @@
 import React from 'react'
 
 export const useTabNotification = () => {
-  const [notifications, setNotifications] = React.useState(1)
+  const [notifications, setNotifications] = React.useState(0)
   const [pageIsInView, setPageIsInView] = React.useState(true)
 
   React.useEffect(() => {

--- a/src/hooks/useTabNotification.ts
+++ b/src/hooks/useTabNotification.ts
@@ -1,0 +1,35 @@
+import React from 'react'
+
+export const useTabNotification = () => {
+  const [notifications, setNotifications] = React.useState(1)
+  const [pageIsInView, setPageIsInView] = React.useState(true)
+
+  React.useEffect(() => {
+    const handleVisibilityChange = () => {
+      setPageIsInView(document.hidden)
+
+      if (document.hidden === false) {
+        document.title = 'Chat'
+      }
+    }
+
+    window.addEventListener('visibilitychange', handleVisibilityChange)
+
+    return () =>
+      window.removeEventListener('visibilitychange', handleVisibilityChange)
+  }, [])
+
+  React.useEffect(() => {
+    if (notifications > 0) {
+      document.title = `(${notifications}) Chat`
+    }
+  }, [notifications])
+
+  const addNotification = () => {
+    if (!pageIsInView && notifications) {
+      setNotifications(notifications + 1)
+    }
+  }
+
+  return addNotification
+}

--- a/src/hooks/useTabNotification.ts
+++ b/src/hooks/useTabNotification.ts
@@ -10,6 +10,7 @@ export const useTabNotification = () => {
 
       if (document.hidden === false) {
         document.title = 'Chat'
+        setNotifications(0)
       }
     }
 

--- a/src/hooks/useTabNotification.ts
+++ b/src/hooks/useTabNotification.ts
@@ -26,7 +26,7 @@ export const useTabNotification = () => {
   }, [notifications])
 
   const addNotification = () => {
-    if (!pageIsInView && notifications) {
+    if (!pageIsInView) {
       setNotifications(notifications + 1)
     }
   }


### PR DESCRIPTION
This PR displays a notification indicator in the browser tab. The notification is only added if the chat is not focused and the indicator is removed whenever the user navigates back to the chat.

| With notification | After opening the tab the notification is removed |
| ------ | ----- |
| <img width="112" alt="Skärmavbild 2021-06-18 kl  14 11 11" src="https://user-images.githubusercontent.com/1478102/122559070-1fcd5700-d03f-11eb-9538-ce0a3ac8b6f1.png"> | <img width="67" alt="Skärmavbild 2021-06-18 kl  14 11 17" src="https://user-images.githubusercontent.com/1478102/122559073-20fe8400-d03f-11eb-9a07-835e7fcb45c4.png"> | 

